### PR TITLE
Added sample data balance for Checking and Savings accounts

### DIFF
--- a/BankApp/BankApp/ModelLayer/Checking.swift
+++ b/BankApp/BankApp/ModelLayer/Checking.swift
@@ -57,3 +57,7 @@ extension Checking: Account {
     
     
 }
+
+struct CheckingBalance {
+    var balance = 100.00
+}

--- a/BankApp/BankApp/ModelLayer/Savings.swift
+++ b/BankApp/BankApp/ModelLayer/Savings.swift
@@ -54,3 +54,7 @@ extension Savings: Account {
     
     
 }
+
+struct SavingsBalance {
+    var balance = 200.00
+}


### PR DESCRIPTION
Here, I set up a struct the hold the sample balance data for both Checking and Savings classes. This should be able to be changed later is we end up adding more of our nice-to-have features.

My rationale behind this was that these structs represent values that might be held in a database, and can be used to populate the class member variables in Checking and Savings upon load (similar to how Erika did it in her contact-list app).